### PR TITLE
fix a multitude of segfaults

### DIFF
--- a/excel.c
+++ b/excel.c
@@ -95,8 +95,8 @@ static zend_object_handlers excel_object_handlers_format;
 static zend_object_handlers excel_object_handlers_font;
 
 typedef struct _excel_book_object {
-	zend_object	std;
 	BookHandle book;
+	zend_object std;
 } excel_book_object;
 
 static inline excel_book_object *php_excel_book_object_fetch_object(zend_object *obj) {
@@ -116,9 +116,9 @@ static inline excel_book_object *php_excel_book_object_fetch_object(zend_object 
 	}
 
 typedef struct _excel_sheet_object {
-	zend_object	std;
 	SheetHandle	sheet;
 	BookHandle book;
+	zend_object std;
 } excel_sheet_object;
 
 static inline excel_sheet_object *php_excel_sheet_object_fetch_object(zend_object *obj) {
@@ -149,9 +149,9 @@ static inline excel_sheet_object *php_excel_sheet_object_fetch_object(zend_objec
 	}
 
 typedef struct _excel_font_object {
-	zend_object	std;
 	FontHandle font;
 	BookHandle book;
+	zend_object std;
 } excel_font_object;
 
 static inline excel_font_object *php_excel_font_object_fetch_object(zend_object *obj) {
@@ -180,9 +180,9 @@ static inline excel_font_object *php_excel_font_object_fetch_object(zend_object 
 	}
 
 typedef struct _excel_format_object {
-	zend_object	std;
 	FormatHandle format;
 	BookHandle book;
+	zend_object std;
 } excel_format_object;
 
 static inline excel_format_object *php_excel_format_object_fetch_object(zend_object *obj) {


### PR DESCRIPTION
PHP7 requires the zend_object in the backing structs to come last which is also reflected by the various fetch_object functions that all subtract from the zend_object pointer.

With this, most tests pass. I still get test failures for
- 002.phpt with an offset of -3600s, so I think this might be a DST issue in the test itself
- 020.phpt fails because what was an `Exception` is now an `Error` in PHP7
- 021.phpt fails for the same reason
- 089.phpt fails for a yet unknown reason.

I will create further PRs to fix the tests in order to keep changes separate.
