### PR TITLE
Check setkey

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -86,6 +86,11 @@ if test "$PHP_EXCEL" != "no"; then
     -L$EXCEL_LIBDIR
   ])
 
+  PHP_CHECK_LIBRARY(xl,xlBookSetKeyA,
+  [
+    AC_DEFINE(HAVE_LIBXL_SETKEY,1,[ ])
+  ],[],[])
+
   if test `grep -c FILLPATTERN_HORSTRIPE $EXCEL_INCDIR/enum.h` -eq 1; then
     AC_DEFINE(HAVE_LIBXL_243_PLUS,1,[ ])
   fi

--- a/excel.c
+++ b/excel.c
@@ -354,6 +354,18 @@ static zend_object *excel_format_object_clone(zval *this_ptr)
 #define EXCEL_METHOD(class_name, function_name) \
 	PHP_METHOD(Excel ## class_name, function_name)
 
+/* {{{ proto bool ExcelBook::requiresKey()
+	true if license key is required. */
+EXCEL_METHOD(Book, requiresKey)
+{
+#if defined(HAVE_LIBXL_SETKEY)
+	RETURN_BOOL(1);
+#else
+	RETURN_BOOL(0);
+#endif
+}
+/* }}} */
+
 /* {{{ proto bool ExcelBook::load(string data)
 	Load Excel data string. */
 EXCEL_METHOD(Book, load)
@@ -4495,6 +4507,9 @@ EXCEL_METHOD(Sheet, printArea)
 
 #endif
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_Book_requiresKey, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_Book_load, 0, 0, 1)
 	ZEND_ARG_INFO(0, data)
 ZEND_END_ARG_INFO()
@@ -5365,6 +5380,7 @@ ZEND_END_ARG_INFO()
 	PHP_ME(Excel ## class_name, function_name, arg_info, flags)
 
 zend_function_entry excel_funcs_book[] = {
+	EXCEL_ME(Book, requiresKey, arginfo_Book_requiresKey, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 	EXCEL_ME(Book, addFont, arginfo_Book_addFont, 0)
 	EXCEL_ME(Book, addFormat, arginfo_Book_addFormat, 0)
 	EXCEL_ME(Book, getAllFormats, arginfo_Book_getAllFormats, 0)

--- a/excel.c
+++ b/excel.c
@@ -1135,6 +1135,20 @@ EXCEL_METHOD(Book, __construct)
 		RETURN_FALSE;
 	}
 
+	BOOK_FROM_OBJECT(book, object);
+
+	if (new_excel) {
+		excel_book_object *obj = (excel_book_object*) Z_EXCEL_BOOK_OBJ_P(object);
+		if ((book = xlCreateXMLBook())) {
+			xlBookRelease(obj->book);
+			obj->book = book;
+		} else {
+			RETURN_FALSE;
+		}
+	}
+
+#if defined(HAVE_LIBXL_SETKEY)
+
 	if (INI_STR("excel.license_name") && INI_STR("excel.license_key")) {
 		name = INI_STR("excel.license_name");
 		name_len = strlen(name);
@@ -1160,19 +1174,9 @@ EXCEL_METHOD(Book, __construct)
 		RETURN_FALSE;
 	}
 
-	BOOK_FROM_OBJECT(book, object);
-
-	if (new_excel) {
-		excel_book_object *obj = (excel_book_object*) Z_EXCEL_BOOK_OBJ_P(object);
-		if ((book = xlCreateXMLBook())) {
-			xlBookRelease(obj->book);
-			obj->book = book;
-		} else {
-			RETURN_FALSE;
-		}
-	}
-
 	xlBookSetKey(book, name_zs->val, key_zs->val);
+
+#endif
 }
 /* }}} */
 

--- a/excel.c
+++ b/excel.c
@@ -69,8 +69,10 @@ ZEND_DECLARE_MODULE_GLOBALS(excel)
 static PHP_GINIT_FUNCTION(excel);
 
 PHP_INI_BEGIN()
+#if defined(HAVE_LIBXL_SETKEY)
 	STD_PHP_INI_ENTRY("excel.license_name", NULL, PHP_INI_ALL, OnUpdateString, ini_license_name, zend_excel_globals, excel_globals)
 	STD_PHP_INI_ENTRY("excel.license_key", NULL, PHP_INI_ALL, OnUpdateString, ini_license_key, zend_excel_globals, excel_globals)
+#endif
 	STD_PHP_INI_ENTRY("excel.skip_empty", "0", PHP_INI_ALL, OnUpdateLong, ini_skip_empty, zend_excel_globals, excel_globals)
 PHP_INI_END()
 

--- a/tests/000.phpt
+++ b/tests/000.phpt
@@ -3,7 +3,7 @@ LibXL licensed version vs trial version test
 --INI--
 date.timezone=America/Toronto
 --SKIPIF--
-<?php if (!extension_loaded("excel")) print "skip"; ?>
+<?php if (!extension_loaded("excel") || !ExcelBook::requiresKey()) print "skip"; ?>
 --FILE--
 <?php 
     $data = array("foo");

--- a/tests/020.phpt
+++ b/tests/020.phpt
@@ -5,18 +5,18 @@ date.timezone=America/Toronto
 --SKIPIF--
 <?php if (!extension_loaded("excel")) print "skip"; ?>
 --FILE--
-<?php 
+<?php
 	$x = new ExcelBook();
 
 	try {
 		$format = new ExcelFormat();
-	} catch (Exception $e) {
+	} catch (Throwable $e) {
 		var_dump($e->getMessage());
 	}
 
 	try {
 		$format = new ExcelFormat('cdsd');
-	} catch (Exception $e) {
+	} catch (Throwable $e) {
 		var_dump($e->getMessage());
 	}
 
@@ -24,5 +24,5 @@ date.timezone=America/Toronto
 ?>
 --EXPECTF--
 string(63) "ExcelFormat::__construct() expects exactly 1 parameter, 0 given"
-
-Catchable fatal error: Argument 1 passed to ExcelFormat::__construct() must be an instance of ExcelBook, string given in %s on line %d
+string(94) "Argument 1 passed to ExcelFormat::__construct() must be an instance of ExcelBook, string given"
+OK

--- a/tests/021.phpt
+++ b/tests/021.phpt
@@ -5,22 +5,23 @@ date.timezone=America/Toronto
 --SKIPIF--
 <?php if (!extension_loaded("excel")) print "skip"; ?>
 --FILE--
-<?php 
+<?php
 	$x = new ExcelBook();
 
 	try {
 		$format = new ExcelFont();
-	} catch (Exception $e) {
+	} catch (Throwable $e) {
 		var_dump($e->getMessage());
 	}
 
 	try {
 		$format = new ExcelFont('cdsd');
-	} catch (Exception $e) {
+	} catch (Throwable $e) {
 		var_dump($e->getMessage());
 	}
+	echo "OK\n"
 ?>
 --EXPECTF--
 string(61) "ExcelFont::__construct() expects exactly 1 parameter, 0 given"
-
-Catchable fatal error: Argument 1 passed to ExcelFont::__construct() must be an instance of ExcelBook, string given in %s on line %d
+string(92) "Argument 1 passed to ExcelFont::__construct() must be an instance of ExcelBook, string given"
+OK

--- a/tests/086.phpt
+++ b/tests/086.phpt
@@ -1,7 +1,7 @@
 --TEST--
 test Sheet::isLicensed()
 --SKIPIF--
-<?php if (!extension_loaded("excel")) print "skip"; ?>
+<?php if (!extension_loaded("excel") || !ExcelBook::requiresKey()) print "skip"; ?>
 --FILE--
 <?php
 

--- a/tests/089.phpt
+++ b/tests/089.phpt
@@ -31,7 +31,7 @@ bool(true)
 bool(false)
 bool(false)
 bool(false)
-string(5) "=3+4"
-string(1) ""
-string(2) "3"
+string(4) "=3+4"
+string(0) ""
+string(1) "3"
 OK


### PR DESCRIPTION
As I said in my comment in #1, this adds support to detect when libxl was built from source ode (and thus doesn't export `xlBookSetKey`).

This also fixes the tests which fail when using that version of libxl
