### PR TITLE
Fix tests

### DIFF
--- a/tests/020.phpt
+++ b/tests/020.phpt
@@ -5,18 +5,18 @@ date.timezone=America/Toronto
 --SKIPIF--
 <?php if (!extension_loaded("excel")) print "skip"; ?>
 --FILE--
-<?php 
+<?php
 	$x = new ExcelBook();
 
 	try {
 		$format = new ExcelFormat();
-	} catch (Exception $e) {
+	} catch (Throwable $e) {
 		var_dump($e->getMessage());
 	}
 
 	try {
 		$format = new ExcelFormat('cdsd');
-	} catch (Exception $e) {
+	} catch (Throwable $e) {
 		var_dump($e->getMessage());
 	}
 
@@ -24,5 +24,5 @@ date.timezone=America/Toronto
 ?>
 --EXPECTF--
 string(63) "ExcelFormat::__construct() expects exactly 1 parameter, 0 given"
-
-Catchable fatal error: Argument 1 passed to ExcelFormat::__construct() must be an instance of ExcelBook, string given in %s on line %d
+string(94) "Argument 1 passed to ExcelFormat::__construct() must be an instance of ExcelBook, string given"
+OK

--- a/tests/021.phpt
+++ b/tests/021.phpt
@@ -5,22 +5,23 @@ date.timezone=America/Toronto
 --SKIPIF--
 <?php if (!extension_loaded("excel")) print "skip"; ?>
 --FILE--
-<?php 
+<?php
 	$x = new ExcelBook();
 
 	try {
 		$format = new ExcelFont();
-	} catch (Exception $e) {
+	} catch (Throwable $e) {
 		var_dump($e->getMessage());
 	}
 
 	try {
 		$format = new ExcelFont('cdsd');
-	} catch (Exception $e) {
+	} catch (Throwable $e) {
 		var_dump($e->getMessage());
 	}
+	echo "OK\n"
 ?>
 --EXPECTF--
 string(61) "ExcelFont::__construct() expects exactly 1 parameter, 0 given"
-
-Catchable fatal error: Argument 1 passed to ExcelFont::__construct() must be an instance of ExcelBook, string given in %s on line %d
+string(92) "Argument 1 passed to ExcelFont::__construct() must be an instance of ExcelBook, string given"
+OK

--- a/tests/089.phpt
+++ b/tests/089.phpt
@@ -31,7 +31,7 @@ bool(true)
 bool(false)
 bool(false)
 bool(false)
-string(5) "=3+4"
-string(1) ""
-string(2) "3"
+string(4) "=3+4"
+string(0) ""
+string(1) "3"
 OK


### PR DESCRIPTION
This fixes all the tests that needed fixing. With this (and if you're using a libxl build with source code, then you also need my previous PR #2) all tests but 

`Excel date pack/unpack tests [tests/002.phpt]`

I have analyzed that failing test. It fails if `date.timezone` is set to something that's not the actual time zone of the local machine (conversely, it passes if `date.timezone` is set to the actual time zone of the local machine).

Fixing it is tricky though:
- either we write all our timestamps in UTC to the excel file (which probably will just confuse the majority of the users) or
- we need a way to convert the date read from excel into a timestamp while going through php's internal DateTime facility. Unfortunately, the `date` extension provides no such thing, so this would come with huge duplication in the code.

The problem is that `_php_excel_date_unpack` calls `mktime()` which of course uses the OSes timezone and not the one set to php internally, so the timestamp `_php_excel_date_unpack` returns in in actual local time and not in the timezone set in `date.timezone`.

I'm tempted to leave this as is.
